### PR TITLE
fix(map): prevent user marker from blocking tree marker clicks

### DIFF
--- a/frontend/src/components/map/MapControls.svelte
+++ b/frontend/src/components/map/MapControls.svelte
@@ -33,7 +33,10 @@
 				duration: 1.5
 			});
 
-			userMarker = L.marker(e.latlng, { icon: userMarkerIcon() }).addTo(map);
+			userMarker = L.marker(e.latlng, { 
+				icon: userMarkerIcon(), 
+				interactive: false 
+			}).addTo(map);
 		});
 
 		map.once('locationerror', () => {


### PR DESCRIPTION
🤬 **Problem:**
- In der aktuellen Live-Version blockiert der Radius um den User-Marker das Anklicken der Bäume darunter
- Das ist beim Review durchgeschlüpft, weil die Bäume zu weit weg vom OIC stehen

➡️ #48 

😇 **Fix:**
- Ich habe beim Marker (`src/components/MapControls.svelte`) die Eigenschaft `interactive: false` gesetzt, damit er keine Mausereignisse mehr empfangen kann
- Habe das direkt am/vorm Baum getestet ➡️ funktioniert jetzt wie gewünscht ✅
- Ggf. beim Review Spazieren gehen 🌳