### PR TITLE
Fix/cors delete user fn

### DIFF
--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,14 +1,14 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7'
 
-const allowedOrigin = 'https://baumbie.org'
+const allowedOrigins = ['https://baumbie.org', 'http://localhost:5173'];
 
 serve(async (req) => {
   const origin = req.headers.get('origin')
 
   // Globale Origin-Check – sofort blockieren, wenn nicht erlaubt
-  if (origin !== allowedOrigin) {
-    return new Response('Forbidden – invalid origin', { status: 403 })
+  if (!origin || !allowedOrigins.includes(origin)) {
+    return new Response('Forbidden', { status: 403 });
   }
 
   // CORS Preflight
@@ -16,7 +16,7 @@ serve(async (req) => {
     return new Response(null, {
       status: 204,
       headers: {
-        'Access-Control-Allow-Origin': allowedOrigin,
+        'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Authorization, Content-Type',
       },
@@ -29,7 +29,7 @@ serve(async (req) => {
   if (!token) {
     return new Response('Unauthorized – no token', {
       status: 401,
-      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+      headers: { 'Access-Control-Allow-Origin': origin },
     })
   }
 
@@ -41,14 +41,14 @@ serve(async (req) => {
   } catch (e) {
     return new Response('Invalid token', {
       status: 401,
-      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+      headers: { 'Access-Control-Allow-Origin': origin },
     })
   }
 
   if (!userId) {
     return new Response('Unauthorized – no user ID', {
       status: 401,
-      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+      headers: { 'Access-Control-Allow-Origin': origin },
     })
   }
 
@@ -63,12 +63,12 @@ serve(async (req) => {
   if (error) {
     return new Response(error.message, {
       status: 400,
-      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+      headers: { 'Access-Control-Allow-Origin': origin },
     })
   }
 
   return new Response('User deleted', {
     status: 200,
-    headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+    headers: { 'Access-Control-Allow-Origin': origin },
   })
 })

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,67 +1,74 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7'
 
-serve(async (req) => {
-  const origin = req.headers.get('origin') ?? '*';
+const allowedOrigin = 'https://baumbie.org'
 
-  // 1. CORS-Preflight-Handling
+serve(async (req) => {
+  const origin = req.headers.get('origin')
+
+  // Globale Origin-Check – sofort blockieren, wenn nicht erlaubt
+  if (origin !== allowedOrigin) {
+    return new Response('Forbidden – invalid origin', { status: 403 })
+  }
+
+  // CORS Preflight
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       status: 204,
       headers: {
-        'Access-Control-Allow-Origin': origin,
+        'Access-Control-Allow-Origin': allowedOrigin,
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Authorization, Content-Type',
       },
-    });
+    })
   }
 
-  const authHeader = req.headers.get('Authorization') || '';
-  const token = authHeader.replace('Bearer ', '');
+  const authHeader = req.headers.get('Authorization') || ''
+  const token = authHeader.replace('Bearer ', '')
 
   if (!token) {
     return new Response('Unauthorized – no token', {
       status: 401,
-      headers: { 'Access-Control-Allow-Origin': origin },
-    });
+      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+    })
   }
 
-  // 2. JWT decodieren (sub = user ID)
-  let userId: string | null = null;
+  // JWT auslesen
+  let userId: string | null = null
   try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
-    userId = payload.sub;
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    userId = payload.sub
   } catch (e) {
     return new Response('Invalid token', {
       status: 401,
-      headers: { 'Access-Control-Allow-Origin': origin },
-    });
+      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+    })
   }
 
   if (!userId) {
     return new Response('Unauthorized – no user ID', {
       status: 401,
-      headers: { 'Access-Control-Allow-Origin': origin },
-    });
+      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+    })
   }
 
-  // 3. Supabase Admin Client mit Service Role Key
+  // Supabase Admin Client
   const supabase = createClient(
     Deno.env.get('SUPABASE_URL')!,
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-  );
+  )
 
-  const { error } = await supabase.auth.admin.deleteUser(userId);
+  const { error } = await supabase.auth.admin.deleteUser(userId)
 
   if (error) {
     return new Response(error.message, {
       status: 400,
-      headers: { 'Access-Control-Allow-Origin': origin },
-    });
+      headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+    })
   }
 
   return new Response('User deleted', {
     status: 200,
-    headers: { 'Access-Control-Allow-Origin': origin },
-  });
-});
+    headers: { 'Access-Control-Allow-Origin': allowedOrigin },
+  })
+})


### PR DESCRIPTION
## 🛡️ CORS-Policy für `deleteUser`-Edge-Function angepasst

Die `deleteUser`-Edge-Function hatte zuvor eine sehr permissive CORS-Konfiguration (`'*'`), was ein potenzielles Sicherheitsrisiko darstellt.

In diesem PR habe ich die CORS-Policy wie folgt eingeschränkt:

- ✅ Erlaubt sind nur Anfragen von `https://baumbie.org` (Produktivumgebung)
- ✅ Zusätzlich ist `http://localhost:5173` für lokale Entwicklung erlaubt
- ❌ Alle anderen Origins erhalten jetzt `403 Forbidden`

**Ziel:** Nur vertrauenswürdige Clients können den Lösch-Endpunkt aufrufen – bei gleichzeitig einfacher lokaler Entwicklung.