### PR TITLE
fix(auth): prevent duplicate registration for unconfirmed users

### DIFF
--- a/frontend/src/components/auth/ConfirmRegistration.svelte
+++ b/frontend/src/components/auth/ConfirmRegistration.svelte
@@ -14,6 +14,8 @@
 </script>
 
 <p>
-	Wir haben eine Bestätigungsmail an <strong>{userEmail}</strong> gesendet. <br />
+	Wir haben über unseren Authentifizierungsdienst <strong>Supabase</strong> eine Bestätigungsmail an
+	<strong>{userEmail}</strong>
+	gesendet. <br />
 	Bitte klicke auf den Link darin, um dein Benutzerkonto zu aktivieren.
 </p>

--- a/frontend/src/lib/supabase/auth.ts
+++ b/frontend/src/lib/supabase/auth.ts
@@ -10,27 +10,23 @@ export async function registerWithEmailPassword(email: string, password: string)
 			throw new Error('Passwort muss mindestens 6 Zeichen lang sein.');
 		}
 
-		// E-Mail bereits vergeben
-		if (error.message.toLowerCase().includes('user already registered')) {
-			throw new Error('Diese E-Mail-Adresse ist bereits registriert.');
-		}
-
 		throw error; // Unbekannter Fehler
-	}
-
-	if (data.user && !data.session) {
-		throw new Error('Diese E-Mail-Adresse ist bereits registriert.');
 	}
 
 	if (!data.user?.id) {
 		throw new Error('Registrierung fehlgeschlagen. Bitte versuche es erneut.');
 	}
 
-	return data;
+	if (data.user.identities?.length === 0) {
+		throw new Error('Diese E-Mail-Adresse ist bereits registriert.');
+	}
+
+	return {
+		user: data.user,
+		emailConfirmationRequired: !data.session,
+	};
+
 }
-
-
-
 
 export async function loginWithEmailPassword(email: string, password: string) {
 	const { data, error } = await supabase.auth.signInWithPassword({ email, password });


### PR DESCRIPTION
## 🛠 Fehlerhafte Registrierung für bestehende Benutzer behoben

### ✨ Was wurde behoben?

Dieser PR behebt ein Problem im E-Mail/Passwort-Registrierungsprozess:

- Nutzer:innen bekamen **fälschlicherweise die Fehlermeldung "E-Mail-Adresse bereits registriert"**, auch wenn die Registrierung korrekt war - und sogar Supabase Auth Mails verschickt worden sind!
- Ursache war eine **fehlerhafte Bedingung**, die `session === null` als Fehler interpretierte – was bei aktivierter E-Mail-Bestätigung jedoch der Normalfall ist.
- Gleichzeitig konnten sich Nutzer **mehrfach mit derselben (nicht bestätigten) E-Mail registrieren**, was zu inkonsistentem Verhalten führte.

---

### ✅ Änderungen in diesem PR

- Die fehlerhafte `if`-Abfrage wurde entfernt bzw. korrigiert.
- Stattdessen wird nun geprüft, ob `user.identities.length === 0` ist – ein sicherer Hinweis darauf, dass die E-Mail bereits registriert ist.
- Nutzer:innen erhalten in diesem Fall eine passende Fehlermeldung und werden bei Bedarf automatisch zur Login-Seite weitergeleitet.
- Die `isSubmitting`-Logik wurde aufgeräumt, sodass UI-Zustände (Button-Text etc.) korrekt reagieren.

---

### 📌 Warum das wichtig ist

Das verhindert:
- verwirrende Fehlermeldungen bei korrekter Registrierung,
- Mehrfach-Registrierungen mit derselben E-Mail-Adresse,
- und inkonsistente Supabase-User ohne gültige Identität.

Der Registrierungsprozess ist damit robuster und benutzerfreundlicher.
