### PR TITLE
Fix: Visuelles Feedback der Baumarten-Filterbuttons auf Mobilgeräten

### DIFF
--- a/frontend/src/components/ui/Button.svelte
+++ b/frontend/src/components/ui/Button.svelte
@@ -13,11 +13,15 @@
 	export let onClick: (e: MouseEvent) => void = () => {};
 
 	const variantClasses: Record<ButtonVariant, string> = {
-		default: 'border-black text-black hover:bg-green-800 hover:text-white',
-		primary: 'border-green-600 bg-green-600 text-white hover:bg-green-800',
-		secondary: 'border-green-500 text-black hover:bg-green-100',
-		danger: 'border-red-600 text-black hover:bg-red-800 hover:text-white',
-		watering: 'border-[#7C98B2] bg-[#7C98B2] text-white hover:brightness-110'
+		default:
+			'border-black text-black bg-white active:bg-gray-200 active:text-black hover:bg-gray-100 hover:text-black supports-hover:hover:bg-green-800 supports-hover:hover:text-white',
+		primary:
+			'border-green-600 bg-green-600 text-white active:bg-green-700 supports-hover:hover:bg-green-800',
+		secondary: 'border-green-500 text-black active:bg-green-50 supports-hover:hover:bg-green-100',
+		danger:
+			'border-red-600 text-black active:bg-red-700 active:text-white supports-hover:hover:bg-red-800 supports-hover:hover:text-white',
+		watering:
+			'border-[#7C98B2] bg-[#7C98B2] text-white active:brightness-90 supports-hover:hover:brightness-110'
 	};
 </script>
 

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,5 +1,7 @@
-/** @type {import('tailwindcss').Config} */
-export default {
+import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
+
+const config: Config = {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 	theme: {
 		extend: {
@@ -41,5 +43,11 @@ export default {
 			}
 		}
 	},
-	plugins: []
+	plugins: [
+		plugin(({ addVariant }) => {
+			addVariant('supports-hover', '@media (hover: hover)');
+		})
+	]
 };
+
+export default config;


### PR DESCRIPTION
Dieses PR behebt ein Problem, bei dem die visuelle Darstellung der Baumarten-Filterbuttons auf Mobilgeräten inkonsistent war (siehe #93 ).
Obwohl beim erneuten Tippen auf einen aktiven Button der Filter korrekt deaktiviert wurde, blieb der Button weiterhin grün dargestellt – was fälschlicherweise auf einen noch aktiven Filter hindeutete.

### Änderungen im Detail:
- `hover:`-Styles durch `supports-hover:hover:` ersetzt, um Hover-Effekte gezielt auf Geräte mit echter Hover-Fähigkeit zu beschränken (verhindert visuelle Fehler auf Touch-Geräten)
- dafür wurde in der Tailwind-Konfiguration eine eigene `supports-hover`-Variante ergänzt
- im Zuge dessen wurde die Konfigurationsdatei von `tailwind.config.js` zu `tailwind.config.ts` umbenannt (inkl. Typsicherheit und ESM-kompatibler Struktur) – was der Best Practice in TypeScript-Projekten entspricht
- `active:`-Styles ergänzt, um auf Mobilgeräten trotzdem ein direktes visuelles Feedback beim Antippen zu ermöglichen

Das Verhalten ist nun auf allen Geräten konsistent und benutzerfreundlich: Auf Desktoprechnern gibt es weiterhin einen grünen Hover-Effekt, auf Touch-Geräten ein klares Tap-Feedback – ohne Hover-Fehlzustände.