### PR TITLE
currentUser zentral laden und als Prop an Status-Komponenten übergeben

### DIFF
--- a/frontend/src/components/status/AdoptedTrees.svelte
+++ b/frontend/src/components/status/AdoptedTrees.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
-	// Svelte lifecycle
+	// Imports
 	import { onMount, onDestroy } from 'svelte';
-
-	// UI & Actions
 	import { Notice } from '$components/ui';
 	import { FlyToTreeButton } from '$components/actions';
-
-	// Data loading
 	import { loadAdoptedTrees } from '$lib/trees';
-	import { getCurrentUser } from '$lib/supabase';
 
 	// Types
+	import type { User } from '@supabase/supabase-js';
 	import type { TreeMeta } from '$types/tree';
+
+	// Props
+	export let currentUser: User | null = null;
 
 	// State
 	let adoptedTrees: TreeMeta[] = [];
@@ -21,10 +20,13 @@
 	let warningMessage: string | null = null;
 	let warningTimeout: ReturnType<typeof setTimeout> | null = null;
 
+	// Lifecycle
 	onMount(async () => {
+		if (!currentUser) {
+			loading = false;
+			return;
+		}
 		try {
-			const user = await getCurrentUser();
-			loggedIn = !!user;
 			adoptedTrees = await loadAdoptedTrees();
 		} catch (err) {
 			console.error(err);
@@ -33,6 +35,13 @@
 		}
 	});
 
+	onDestroy(() => {
+		if (warningTimeout) {
+			clearTimeout(warningTimeout);
+		}
+	});
+
+	// Functions
 	function showWarning(msg: string) {
 		warningMessage = msg;
 
@@ -45,12 +54,6 @@
 			warningTimeout = null;
 		}, 5000);
 	}
-
-	onDestroy(() => {
-		if (warningTimeout) {
-			clearTimeout(warningTimeout);
-		}
-	});
 </script>
 
 {#if loading}

--- a/frontend/src/components/status/UserWaterings.svelte
+++ b/frontend/src/components/status/UserWaterings.svelte
@@ -1,21 +1,35 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { getCurrentUser, getWateringsForUser } from '$lib/supabase';
+	import { getWateringsForUser } from '$lib/supabase';
 	import { WateringHistory } from '$components/waterings';
 	import { Notice } from '$components/ui';
 	import { loadSpeciesMap } from '$lib/supabase/trees';
 
+	// Types
+	import type { User } from '@supabase/supabase-js';
 	import type { Watering } from '$types/watering';
-	let labelsByTreeId: Map<string, string> = new Map();
 
+	// Props
+	export let currentUser: User | null = null;
+
+	// State
+	let labelsByTreeId: Map<string, string> = new Map();
 	let currentUserId: string | null = null;
 	let loggedIn = false;
-
 	let loading = true;
 	let error: string | null = null;
-
 	let waterings: Watering[] = [];
 
+	// Lifecycle
+	onMount(async () => {
+		if (!currentUser) {
+			loading = false;
+			return;
+		}
+		await loadWaterings();
+	});
+
+	// Load Function
 	async function loadWaterings() {
 		try {
 			loading = true;
@@ -33,24 +47,12 @@
 			loading = false;
 		}
 	}
-
-	onMount(async () => {
-		const user = await getCurrentUser();
-		currentUserId = user?.id ?? null;
-		loggedIn = !!user;
-
-		if (loggedIn) {
-			await loadWaterings();
-		} else {
-			loading = false;
-		}
-	});
 </script>
 
 {#if error}
 	<Notice tone="warning">{error}</Notice>
 {:else if loading}
-	<Notice tone="info">Wird geladen...</Notice>
+	<Notice tone="info">Wird geladen…</Notice>
 {:else if waterings.length > 0}
 	<WateringHistory
 		{waterings}

--- a/frontend/src/routes/status/+page.svelte
+++ b/frontend/src/routes/status/+page.svelte
@@ -1,8 +1,19 @@
 <script lang="ts">
-	import UserMessage from '$components/chat/UserMessage.svelte';
+	import { onMount } from 'svelte';
+	import { PanelSection, Notice } from '$components/ui';
 	import { DialogPanel } from '$components/overlay';
 	import { AdoptedTrees, NearbyTrees, UserWaterings } from '$components/status';
-	import { PanelSection } from '$components/ui';
+	import { getCurrentUser } from '$lib/supabase';
+
+	import type { User } from '@supabase/supabase-js';
+
+	let currentUser: User | null = null;
+	let loadingUser = true;
+
+	onMount(async () => {
+		currentUser = await getCurrentUser();
+		loadingUser = false;
+	});
 </script>
 
 <DialogPanel title={'Mein Bereich'} open={true}>
@@ -10,15 +21,16 @@
 		<PanelSection title="Bäume in meiner Nähe">
 			<NearbyTrees />
 		</PanelSection>
+		{#if loadingUser}
+			<Notice tone="info">Benutzer wird geladen …</Notice>
+		{:else}
+			<PanelSection title="Meine adoptierten Bäume">
+				<AdoptedTrees {currentUser} />
+			</PanelSection>
 
-		<PanelSection title="Meine adoptierten Bäume">
-			<AdoptedTrees />
-		</PanelSection>
-
-		<PanelSection title="Meine Gießfortschritte">
-			<UserWaterings />
-		</PanelSection>
+			<PanelSection title="Meine Gießfortschritte">
+				<UserWaterings {currentUser} />
+			</PanelSection>
+		{/if}
 	</div>
-
-	<!-- Später Inhalt: Dein Gießfortschritt -->
 </DialogPanel>


### PR DESCRIPTION
In diesem PR wird `getCurrentUser()` zentral in der übergeordneten Komponente ("Mein Bereich") geladen und anschließend als Prop an `AdoptedTrees` und `UserWaterings` weitergereicht. 

Zuvor haben beide Komponenten eigenständig `getCurrentUser()` aufgerufen, was zu unnötigen Supabase-Anfragen und spürbaren UI-Verzögerungen, insbesondere bei "Meine adoptierten Bäume", geführt hat.

- `getCurrentUser()` wird nur noch einmal im Parent aufgerufen.
- Die Komponenten `AdoptedTrees` und `UserWaterings` erhalten `currentUser` als Prop.
- Redundante Supabase-Aufrufe entfallen.
- Der Ladezustand betrifft nur die login-abhängigen Panels – `NearbyTrees` bleibt unabhängig.

Diese Änderung verbessert Performance, Übersichtlichkeit und Wiederverwendbarkeit der Komponenten.